### PR TITLE
Fix #164 limit parallel level

### DIFF
--- a/app/service/ImportRepository.scala
+++ b/app/service/ImportRepository.scala
@@ -1,23 +1,18 @@
 package service
 
-import scala.concurrent.Future
-import scala.concurrent.duration.DurationInt
 import client.kio.KioClient
 import client.oauth.OAuth
 import configuration.GeneralConfiguration
-import dao.{ CommitRepository, RepoRepository }
-import javax.inject.{ Inject, Singleton }
+import dao.{CommitRepository, RepoRepository}
+import java.util.concurrent.TimeUnit
+import javax.inject.{Inject, Singleton}
 import model.Repository
 import play.api.Logger
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
 import utility.FutureUtil._
 import utility.UrlParser
-import scala.concurrent.Await
-import scala.concurrent.duration.Duration
-import scala.util.Try
-import scala.util.Failure
-import scala.util.Success
-import java.util.concurrent.TimeUnit
 
 trait ImportRepository {
   def syncApps(): Future[Unit]

--- a/app/utility/FutureUtil.scala
+++ b/app/utility/FutureUtil.scala
@@ -1,13 +1,11 @@
 package utility
 
-import scala.annotation.implicitNotFound
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import play.api.Logger
+import akka.actor.ActorSystem
 import java.sql.SQLException
-import scala.util.Try
-import scala.util.Failure
-import scala.util.Success
+import play.api.Logger
+import scala.annotation.implicitNotFound
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.duration.FiniteDuration
 
 /**
  * @author fbenjamin
@@ -53,5 +51,13 @@ object FutureUtil {
         logger.error(ex.getMessage)
         Future.failed(new Exception("Database operation failed!"))
     }
+
+  def timeoutFuture(actorSys: ActorSystem, du: FiniteDuration)(implicit ec: ExecutionContext): Future[Unit] = {
+    val p = Promise[Unit]
+    actorSys.scheduler.scheduleOnce(du) {
+      p.trySuccess(())
+    }
+    p.future
+  }
 
 }

--- a/app/utility/Transformer.scala
+++ b/app/utility/Transformer.scala
@@ -36,7 +36,7 @@ object Transformer {
     Try(Json.parse(input)) match {
       case Success(result) => Future.successful(result)
       case Failure(ex) =>
-        logger.error("Error while parsing:" + ex.getMessage)
+        logger.error("Error while parsing:" + ex.getMessage, ex)
         Future.failed(new JsonParseException("Failed to parse the json input"))
     }
   }
@@ -51,7 +51,7 @@ object Transformer {
     case Success(result) =>
       Option(result)
     case Failure(ex) =>
-      logger.error("Error while parsing:" + ex.getMessage)
+      logger.error("Error while parsing:" + ex.getMessage, ex)
       None
   }
 
@@ -86,7 +86,7 @@ object Transformer {
     }
   }
   /**
-   * Deserializes an optional JsValue into an optional concrete object of type T. 
+   * Deserializes an optional JsValue into an optional concrete object of type T.
    * instance of  [T] type wrapped in an option.
    * @param input is an optional JsValue
    * @return Option[T] - Contains the an optional deserialized Object
@@ -95,12 +95,12 @@ object Transformer {
     input.flatMap { jasonBourne => deserialize2Option(jasonBourne)
     }
   }
-  
-  
+
+
   /**
    * Deserializes a JsValue into an instance of type T.
    * @param input is an optional JsValue
-   * @return T - An instance of type T 
+   * @return T - An instance of type T
    */
   def deserialize[T](input:JsValue)(implicit rds: Reads[T]): T = {
     deserialize2Option(input) match {

--- a/test/service/ImportCommitTest.scala
+++ b/test/service/ImportCommitTest.scala
@@ -54,7 +54,7 @@ class ImportCommitTest extends FlatSpec with MockitoSugar with MockitoUtils with
   val commit1Repo1 = createCommit(s"commitRepo1-id1", "message", None, author1, None, None, None, dateToday, validRepo1.url)
   val commit2Repo1 = createCommit(s"commitRepo1-id2", "message", None, author1, None, None, None, dateToday, validRepo1.url)
 
-  private val commitImporter = new ImportCommitImpl(oAuthClient, commitRepo, search, repoRepository, config)
+  private val commitImporter = new ImportCommitImpl(actorSystem, oAuthClient, commitRepo, search, repoRepository, config)
 
   before {
     reset(kioClient, oAuthClient, commitRepo, search, scheduler, repoRepository, config)


### PR DESCRIPTION
* re-worked on scheduling of ```ImportCommit.synchCommits```, added interval between each request. currently hard-coded
* fixed exception being thrown at ```Json.parse``` in ```SeachImpl.handleRequest```, when response body is empty or invalid

@kanuku pls have a look since I have changed the tests. (looks like they were wrong)