### PR TITLE
Fix #167 in quick way

### DIFF
--- a/app/client/scm/SCM.scala
+++ b/app/client/scm/SCM.scala
@@ -158,7 +158,7 @@ class SCMImpl @Inject() (dispatcher: RequestDispatcher, //
       case resolver if resolver.hostType == "github" =>
         logger.info(s"Calling(github) HEAD on $url")
         dispatcher.requestHolder(url) //
-          .withHeaders(resolver.accessTokenHeader(host))
+          .withQueryString(resolver.accessTokenHeader(host))
           .head()
       case resolver if resolver.hostType == "stash" =>
         logger.info(s"Calling(stash) GET on $url")

--- a/app/client/scm/SCMResolver.scala
+++ b/app/client/scm/SCMResolver.scala
@@ -173,6 +173,9 @@ sealed trait SCMResolver {
    */
   def startAtPageNumber(pageNr: Int): (String, String)
 
+  /** determine the pagination based on current page/position and number of items on last page */
+  def nextPosition(currPos: Int, lastBatchSize: Int): Int
+
   def isGithubServerType(): Boolean
   /**
    * The access-token value to use for accessing the SCM Rest api.
@@ -241,6 +244,7 @@ class GithubResolver @Inject() (config: SCMConfiguration) extends SCMResolver {
   def isGithubServerType(): Boolean = true
   def sinceCommitQueryParameter(since: String) = ("date" -> since)
   def startAtPageNumber(pageNr: Int) = ("page" -> pageNr.toString())
+  def nextPosition(currPos: Int, lastBatchSize: Int): Int = currPos + 1
 
   //This is should be coming from configuration
   def isBehindOAuthProxy(): Boolean = false
@@ -295,6 +299,7 @@ class StashResolver @Inject() (config: SCMConfiguration, oauth: OAuth) extends S
   def isGithubServerType: Boolean = false
   def sinceCommitQueryParameter(since: String) = ("since" -> since)
   def startAtPageNumber(pageNr: Int) = ("start" -> (pageNr - 1).toString())
+  def nextPosition(currPos: Int, lastBatchSize: Int): Int = currPos + lastBatchSize
 
   //This is should be coming from configuration
   def isBehindOAuthProxy(): Boolean = true

--- a/app/client/scm/SCMResolver.scala
+++ b/app/client/scm/SCMResolver.scala
@@ -229,7 +229,7 @@ class GithubResolver @Inject() (config: SCMConfiguration) extends SCMResolver {
   }
   def repoUrl(host: String, project: String, repository: String) = s"https://$host/$project/$repository"
 
-  def checkRepoUrl(host: String, project: String, repository: String) = repoUrl(host, project, repository)
+  def checkRepoUrl(host: String, project: String, repository: String) = repo(host, project, repository)
 
   def diffUrl(host: String, project: String, repository: String, source: String, target: String): String = {
     val antecedent = antecedents(host)

--- a/app/service/Search.scala
+++ b/app/service/Search.scala
@@ -91,6 +91,7 @@ trait Search {
    */
   def diff(host: String, project: String, repository: String, source: String, target: String): Future[Either[String, Option[Link]]]
 
+  def nextPosition(host: String, currPos: Int, lastBatchSize: Int): Either[String, Int]
 }
 
 /**
@@ -180,6 +181,13 @@ class SearchImpl @Inject() (client: SCM, @Named("stash") stashParser: SCMParser,
       }
     }
   }
+
+  def nextPosition(host: String, currPost: Int, lastBatchSize: Int): Either[String, Int] =
+    Try(client.resolver(host)) match {
+      case Failure(_) => Left(s"Can not find resolver implementation for host: $host")
+      case Success(res) =>
+        Right(res.nextPosition(currPost, lastBatchSize))
+    }
 
   def isUrlValid(host: String, url: String): Future[Either[String, Boolean]] = {
     logger.info(s"isUrlValid: $host - $url")

--- a/test/client/scm/SCMTest.scala
+++ b/test/client/scm/SCMTest.scala
@@ -109,7 +109,7 @@ class SCMTest extends FlatSpec with MockitoSugar with MockitoUtils with OneAppPe
     assert(result == url)
   }
   "SCM#checkRepoUrl" should "return a repository-url for github API" in {
-    val url = s"https://$github/$project/$repository"
+    val url = s"https://api.$github/repos/$project/$repository"
     val result = client.checkRepoUrl(github, project, repository)
     assert(result == url)
   }
@@ -134,6 +134,7 @@ class SCMTest extends FlatSpec with MockitoSugar with MockitoUtils with OneAppPe
     val url = s"Test"
     when(mockedDispatcher.requestHolder(url)).thenReturn(mockedRequestHolder)
     when(mockedRequestHolder.withHeaders(any[Tuple2[String, String]]())).thenReturn(mockedRequestHolder)
+    when(mockedRequestHolder.withQueryString(any[Tuple2[String, String]]())).thenReturn(mockedRequestHolder)
     when(mockedRequestHolder.head()).thenReturn(mockedResponse)
     val result = client.head(github, url)
     assert(result == mockedResponse)


### PR DESCRIPTION
* the way to traverse through pages in stash and github is unchanged
* add additional function to determine next pagination parameter based also on number of items in last result
* pagination/traversing through paged results should be fixed in the future to align with stash and github api specification as stated in issue #167 